### PR TITLE
Update help.rst to show how to suppress logger message in notebook

### DIFF
--- a/docs/help.rst
+++ b/docs/help.rst
@@ -95,7 +95,17 @@ Sometimes, this additional logging is enough to help you debug. Before you ask
 for help, carefully read through your logs to see if there's anything there that 
 helps you.
 
+~~~~~~~~~~~~~~
+Disable Logging
+~~~~~~~~~~~~~~
 
+Sometimes you may want to supress verbose messages from logger module
+
+.. code-block:: python
+
+  import logging
+  logging.getLogger('tda.auth').disabled = True # disable auth logger which has default level INFO. 
+  # other possibility is logging.getLogger('tda.auth').setLevel('ERROR') #'INFO','DEBUG','WARNING','ERROR','CRITICAL' options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Gather Logs For Your Bug Report
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Running getquote in a loop was printing logger messages in vscode which I wanted to turn off